### PR TITLE
DBAAS-338

### DIFF
--- a/columnstore/Dockerfile
+++ b/columnstore/Dockerfile
@@ -12,13 +12,13 @@ RUN export USER=root && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     /usr/bin/systemd-machine-id-setup && \
-    chown -R mysql:mysql /usr/local/mariadb/columnstore/mysql && \
     ln -s /usr/local/mariadb/columnstore/lib/libcalmysql.so.1.0.0 /usr/local/mariadb/columnstore/mysql/lib/plugin/libcalmysql.so && \
     ln -s /usr/local/mariadb/columnstore/lib/libudf_mysql.so.1.0.0 /usr/local/mariadb/columnstore/mysql/lib/plugin/libudf_mysql.so && \
     ln -s /usr/local/mariadb/columnstore/lib/is_columnstore_tables.so.1.0.0 /usr/local/mariadb/columnstore/mysql/lib/plugin/is_columnstore_tables.so && \
     ln -s /usr/local/mariadb/columnstore/lib/is_columnstore_columns.so.1.0.0 /usr/local/mariadb/columnstore/mysql/lib/plugin/is_columnstore_columns.so && \
     ln -s /usr/local/mariadb/columnstore/lib/is_columnstore_extents.so.1.0.0 /usr/local/mariadb/columnstore/mysql/lib/plugin/is_columnstore_extents.so && \
-    ln -s /usr/local/mariadb/columnstore/lib/is_columnstore_files.so.1.0.0 /usr/local/mariadb/columnstore/mysql/lib/plugin/is_columnstore_files.so
+    ln -s /usr/local/mariadb/columnstore/lib/is_columnstore_files.so.1.0.0 /usr/local/mariadb/columnstore/mysql/lib/plugin/is_columnstore_files.so && \
+    chown -R mysql:mysql /usr/local/mariadb/columnstore/mysql
 
 COPY service /etc/service/
 COPY dbinit runit_bootstrap wait_for_columnstore_active /usr/sbin/

--- a/columnstore/dbinit
+++ b/columnstore/dbinit
@@ -22,6 +22,10 @@ wait_for_procmon()
     done
 }
 
+# hack to ensure server-id is set to unique value per vm because my.cnf is
+# not in a good location for a volume
+SERVER_ID=$(hostname -i | cut -d "." -f 4)
+sed -i "s/server-id =.*/server-id = $SERVER_ID/" /usr/local/mariadb/columnstore/mysql/my.cnf 
 
 # Initialize CS only once.
 if [ -e $FLAG ]; then
@@ -47,6 +51,11 @@ else
         # columnstore to startup by some other means
         echo "Waiting for columnstore to start to run post install files"
         /usr/sbin/wait_for_columnstore_active
+        if [ 1 -eq $? ]; then
+            # exit now if columnstore did not start
+            echo "ERROR: ColumnStore did not start so custom install files not run."
+            exit 1
+        fi
     fi
 
     # Create custom database for scripts if needed based on CS_DATABASE env var
@@ -77,9 +86,8 @@ else
                 /bin/sh -x $f 2>&1
             fi;
         done;
-        echo "Finish at $(date)"
+        echo "Container initialization complete at $(date)"
     fi
-    echo "Container initialization complete at $(date)"
     touch $FLAG
 fi
 exit 0;

--- a/columnstore/wait_for_columnstore_active
+++ b/columnstore/wait_for_columnstore_active
@@ -1,26 +1,59 @@
 #!/bin/sh
 
+MAX_TRIES=36 # 3 minutes
+if [ ! -z "$CS_WAIT_ATTEMPTS" ]; then
+    MAX_TRIES=$CS_WAIT_ATTEMPTS
+fi
+
+# if argument is -d enable debug output
+if [ $# -gt 0 ] && [ "$1" == "-d" ]; then
+    CS_DEBUG=1
+fi
+
+ATTEMPT=1
 # wait for mcsadmin getSystemStatus to show active
 STATUS=$(/usr/local/mariadb/columnstore/bin/mcsadmin getSystemStatus | tail -n +9 | grep System | grep -v "System and Module statuses")
-echo "mcsadmin getSystemStatus: $STATUS"
+if [ ! -z $CS_DEBUG ]; then
+    echo "wait_for_columnstore_active($ATTEMPT/$MAX_TRIES): getSystemStatus: $STATUS"
+fi
 echo "$STATUS" | grep -q 'System.*ACTIVE'
-while [ 1 -eq $? ]; do
+while [ 1 -eq $? ] && [ $ATTEMPT -le $MAX_TRIES ]; do
     sleep 5
+    ATTEMPT=$(($ATTEMPT+1))
     STATUS=$(/usr/local/mariadb/columnstore/bin/mcsadmin getSystemStatus | tail -n +9 | grep System | grep -v "System and Module statuses")
-    echo "mcsadmin getSystemStatus: $STATUS"
+    if [ ! -z $CS_DEBUG ]; then
+        echo "wait_for_columnstore_active($ATTEMPT/$MAX_TRIES): getSystemStatus: $STATUS"
+    fi
     echo "$STATUS" | grep -q 'System.*ACTIVE'
 done
 
+if [ $ATTEMPT -ge $MAX_TRIES ]; then
+    echo "ERROR: ColumnStore did not start after $MAX_TRIES attempts"
+    exit 1
+fi
+
 # during install the system status can be active but the cs system catalog
-# is still being created, so wait for this to complete.
+# is still being created, so wait for this to complete. This will currently
+# fail if run on a um2 or greater but almost all scripts should only be
+# run on um1 and let replication clone to other ums
 if [ -f "/usr/local/mariadb/columnstore/mysql/bin/mysql" ]; then
     echo "Waiting for system catalog to be fully created"
+    ATTEMPT=1
     STATUS=$(/usr/local/mariadb/columnstore/mysql/bin/mysql -u root test -e "drop table if exists installtest; create table installtest(i tinyint) engine=columnstore;")
-    while [ 1 -eq $? ]; do
-        echo "cs create table test error: $STATUS"
+    while [ 1 -eq $? ] && [ $ATTEMPT -le $MAX_TRIES ]; do
+        if [ ! -z $CS_DEBUG ]; then
+            echo "wait_for_columnstore_active($ATTEMPT/$MAX_TRIES): create table test error: $STATUS"
+        fi
         sleep 2
+        ATTEMPT=$(($ATTEMPT+1))
         STATUS=$(/usr/local/mariadb/columnstore/mysql/bin/mysql -u root test -e "drop table if exists installtest; create table installtest(i tinyint) engine=columnstore;")
     done
     /usr/local/mariadb/columnstore/mysql/bin/mysql -u root test -e "drop table if exists installtest;"
-    echo "System ready"
+    if [ $ATTEMPT -ge $MAX_TRIES ]; then
+        echo "ERROR: ColumnStore not ready for use after $MAX_TRIES attempts"
+        exit 1
+    else
+        echo "System ready"
+    fi
 fi
+exit 0


### PR DESCRIPTION
Disable wait_for_columnstore_active output unless CS_DEBUG=1 specified as env variable.
Add configurable amount of retries in wait_for_columnstore_active
Add logic to update server-id in my.cnf to last digit of ip every restart in dbinit to make replication work