### PR TITLE
DBAAS-338

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ services: docker
 env:
   - VERSION=columnstore
   - VERSION=columnstore_jupyter
+  - VERSION=columnstore_zeppelin
 
 install:
   - git clone https://github.com/mariadb-corporation/mariadb-docker-images ~/mariadb-docker-images

--- a/columnstore/dbinit
+++ b/columnstore/dbinit
@@ -25,7 +25,7 @@ wait_for_procmon()
 # hack to ensure server-id is set to unique value per vm because my.cnf is
 # not in a good location for a volume
 SERVER_ID=$(hostname -i | cut -d "." -f 4)
-sed -i "s/server-id =.*/server-id = $SERVER_ID/" /usr/local/mariadb/columnstore/mysql/my.cnf 
+sed -i "s/server-id =.*/server-id = $SERVER_ID/" /usr/local/mariadb/columnstore/mysql/my.cnf
 
 # Initialize CS only once.
 if [ -e $FLAG ]; then
@@ -77,13 +77,29 @@ else
             if [[ $f == *.sql ]];then
                 echo "Run $f at $(date)"
                 $MCSMYCMD -vvv $DBNAME < $f 2>&1
+                if [ 1 -eq $? ]; then
+                    echo "Script $f failed, aborting setup"
+                    exit 1
+                fi
             elif [[ $f == *.sql.gz ]];then
                 echo "Run $f at $(date)"
                 zcat $f | $MCSMYCMD -vvv $DBNAME 2>&1
+                if [ 1 -eq $? ]; then
+                    echo "Script $f failed, aborting setup"
+                    exit 1
+                fi
             elif [[ $f == *.sh ]]; then
                 chmod 755 $f
                 echo "Run $f at $(date)"
-                /bin/sh -x $f 2>&1
+                if [ -z $CS_DEBUG ]; then
+                    /bin/sh $f 2>&1
+                else
+                    /bin/sh -x $f 2>&1
+                fi
+                if [ 1 -eq $? ]; then
+                    echo "Script $f failed, aborting setup"
+                    exit 1
+                fi
             fi;
         done;
         echo "Container initialization complete at $(date)"

--- a/columnstore/wait_for_columnstore_active
+++ b/columnstore/wait_for_columnstore_active
@@ -43,9 +43,9 @@ if [ -f "/usr/local/mariadb/columnstore/mysql/bin/mysql" ]; then
     while [ 1 -eq $? ] && [ $ATTEMPT -le $MAX_TRIES ]; do
         if [ ! -z $CS_DEBUG ]; then
             echo "wait_for_columnstore_active($ATTEMPT/$MAX_TRIES): create table test error: $STATUS"
-        f
+        fi
         echo "$STATUS" | grep -q "DML and DDL statements for Columnstore tables can only be run from the replication master."
-        if [ 1 -eq $? ]; then
+        if [ 0 -eq $? ]; then
             echo "Not um1 so assuming system ready"
             exit 0
         fi

--- a/columnstore/wait_for_columnstore_active
+++ b/columnstore/wait_for_columnstore_active
@@ -39,14 +39,19 @@ fi
 if [ -f "/usr/local/mariadb/columnstore/mysql/bin/mysql" ]; then
     echo "Waiting for system catalog to be fully created"
     ATTEMPT=1
-    STATUS=$(/usr/local/mariadb/columnstore/mysql/bin/mysql -u root test -e "drop table if exists installtest; create table installtest(i tinyint) engine=columnstore;")
+    STATUS=$(/usr/local/mariadb/columnstore/mysql/bin/mysql -u root test -e "drop table if exists installtest; create table installtest(i tinyint) engine=columnstore;" 2>&1)
     while [ 1 -eq $? ] && [ $ATTEMPT -le $MAX_TRIES ]; do
         if [ ! -z $CS_DEBUG ]; then
             echo "wait_for_columnstore_active($ATTEMPT/$MAX_TRIES): create table test error: $STATUS"
+        f
+        echo "$STATUS" | grep -q "DML and DDL statements for Columnstore tables can only be run from the replication master."
+        if [ 1 -eq $? ]; then
+            echo "Not um1 so assuming system ready"
+            exit 0
         fi
         sleep 2
         ATTEMPT=$(($ATTEMPT+1))
-        STATUS=$(/usr/local/mariadb/columnstore/mysql/bin/mysql -u root test -e "drop table if exists installtest; create table installtest(i tinyint) engine=columnstore;")
+        STATUS=$(/usr/local/mariadb/columnstore/mysql/bin/mysql -u root test -e "drop table if exists installtest; create table installtest(i tinyint) engine=columnstore;" 2>&1)
     done
     /usr/local/mariadb/columnstore/mysql/bin/mysql -u root test -e "drop table if exists installtest;"
     if [ $ATTEMPT -ge $MAX_TRIES ]; then

--- a/columnstore_zeppelin/docker-compose.yml
+++ b/columnstore_zeppelin/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - um2_etc:/usr/local/mariadb/columnstore/etc
       - um2_mysql:/usr/local/mariadb/columnstore/mysql/db
       - um2_local:/usr/local/mariadb/columnstore/local
+      - ./multi_node_um2:/docker-entrypoint-initdb.d
     networks:
       mcsnet:
         ipv4_address: 10.5.0.3
@@ -59,7 +60,7 @@ services:
   zeppelin:
     hostname: zeppelin
     build: ../columnstore_zeppelin
-  
+
     ports:
       - "8080:8080"
     depends_on:
@@ -93,4 +94,3 @@ networks:
      config:
        - subnet: 10.5.0.0/16
          gateway: 10.5.0.1
-

--- a/columnstore_zeppelin/multi_node_um1/01_0_wait_for_um2_slave_start.sh
+++ b/columnstore_zeppelin/multi_node_um1/01_0_wait_for_um2_slave_start.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+MAX_TRIES=36
+if [ ! -z "$CS_WAIT_ATTEMPTS" ]; then
+    MAX_TRIES=$CS_WAIT_ATTEMPTS
+fi
+
+# if argument is -d enable debug output
+if [ $# -gt 0 ] && [ "$1" == "-d" ]; then
+    CS_DEBUG=1
+fi
+
+ATTEMPT=1
+# this essentiall waits for the root @um1 login to be created as well as the slave to be started.
+STATUS=$(/usr/local/mariadb/columnstore/mysql/bin/mysql -u root -h um2 -e "show slave status\G" | grep "Waiting for master")
+while [ 1 -eq $? ] && [ $ATTEMPT -le $MAX_TRIES ]; do
+    if [ ! -z $CS_DEBUG ]; then
+        echo "wait_for_um2_slave_start($ATTEMPT/$MAX_TRIES): $STATUS"
+    fi
+    sleep 5
+    ATTEMPT=$(($ATTEMPT+1))
+    STATUS=$(/usr/local/mariadb/columnstore/mysql/bin/mysql -u root -h um2 -e "show slave status\G" | grep "Waiting for master")
+done
+
+if [ $ATTEMPT -ge $MAX_TRIES ]; then
+    echo "ERROR: Did not detect slave start on um2 after $MAX_TRIES attempts"
+    exit 1
+fi
+
+exit 0

--- a/columnstore_zeppelin/multi_node_um2/00_add_um1_root_user.sql
+++ b/columnstore_zeppelin/multi_node_um2/00_add_um1_root_user.sql
@@ -1,0 +1,2 @@
+set sql_mode='';
+grant all on *.* to root@10.5.0.2;


### PR DESCRIPTION
Additional changes to ensure um2 is setup correctly for replication of subsequent changes.
This is done by adding allowing um1 to connect to um2 as root mariadb user and then add
a shell script which waits for the replication slave status to show up good. All this fun is needed because replication gets setup asynchronously after the system shows active.