### PR TITLE
MCOL-2068 - explicit memory settings for numBlocksPct and …

### DIFF
--- a/columnstore/Dockerfile
+++ b/columnstore/Dockerfile
@@ -32,7 +32,9 @@ RUN chmod 755 /etc/service/*/run /etc/service/*/finish /usr/sbin/runit_bootstrap
     mkdir /log
 
 # default postConfigure input to create single node cluster
-ENV MARIADB_CS_POSTCFG_INPUT "1\ncolumnstore-1\n1\n1\n"
+ENV MARIADB_CS_POSTCFG_INPUT="1\ncolumnstore-1\n1\n1\n" \
+MARIADB_CS_NUM_BLOCKS_PCT=1024M \
+MARIADB_CS_TOTAL_UM_MEMORY=256M
 
 EXPOSE 3306
 

--- a/columnstore/Readme.MD
+++ b/columnstore/Readme.MD
@@ -1,7 +1,12 @@
-# MariaDB ColumnStore Docker Container Setup
+# MariaDB ColumnStore Development 1.2.x Nightly Docker Container Setup
 
 ## Introduction
 This docker image will startup a single server instance of MariaDB ColumnStore running on CENTOS 7. It is designed and suitable for demo and evaluation.
+
+This setup spins up ColumnStore from the current development branch. It therefore, might contain errors or features that won't be in the final release.
+
+The current development version built is: 1.2.3
+
 
 ## Requirements
 The following are required:
@@ -12,19 +17,19 @@ The following are required:
 
 ## Run Single Instance Container
 
-To pull MariaDB ColumnStore 1.2 version run the following command:
+To build the latest MariaDB ColumnStore 1.2 development version run the following command:
 ```
-docker pull mariadb/columnstore:1.2
+docker build -t mariadb/columnstore:1.2-dev .
 ```
 
 To run MariaDB ColumnStore run the following command:
 ```
-docker run -d --name mcs mariadb/columnstore:1.2
+docker run -d --name mcs mariadb/columnstore:1.2-dev
 ```
 
 To specify a root password:
 ```
-docker run -d --name mcs -eMARIADB_ROOT_PASSWORD=mypassword mariadb/columnstore:1.2
+docker run -d --name mcs -eMARIADB_ROOT_PASSWORD=mypassword mariadb/columnstore:1.2-dev
 ```
 
 The following output will be seen indicating the server is up:
@@ -54,13 +59,15 @@ Container initialization complete at Tue Jul 24 05:16:48 UTC 2018
 The following environment variables can be utilized to configure behavior:
 * MARIADB_ROOT_PASSWORD : specify the password for the root user
 * MARIADB_ALLOW_EMPTY_PASSWORD : allow empty password for the root user
-* MARIADB_RANDOM_ROOT_PASSWORD : generate a random password for the root user (output to logs). Note: This option takes precedence over MARIADB_ROOT_PASSWORD.
+* MARIADB_RANDOM_ROOT_PASSWORD : generate a random password for the root user (output to logs)
 * MARIADB_INITDB_SKIP_TZINFO : skip timezone setup
 * MARIADB_ROOT_HOST : host for root user, defaults to '%'
 * MARIADB_DATABASE : create a database with this name
 * MARIADB_USER : create a user with this name, with all privileges on MARIADB_DATABASE if specified
 * MARIADB_PASSWORD : password for above user
 * MARIADB_CS_POSTCFG_INPUT : override input values for postConfigure. The default value in the Dockerfile will start up a single server deployment. If the environment variable is empty then postConfigure will not be run and the container will just run the ColumnStore service process ProcMon.
+* MARIADB_CS_NUM_BLOCKS_PCT - If set uses this amount of physical memory to utilize for disk block caching. Explicit amounts need to be prefixed with M or G. Will override the default setting of 1024M from Dockerfile.
+- MARIADB_CS_TOTAL_UM_MEMORY - If set uses this amount of physical memory to utilize for joins, intermediate results and set operations on the UM. Explicit amounts need to be prefixed with M or G. Will override the default setting of 256M from Dockerfile.
 * MARIADB_DROP_LOCAL_USERS : Drop anonymous local users, useful for  removing this on non um1 um containers.
 
 Note that the ColumnStore docker image differs from the MariaDB server docker image in that  it does not mandate specification of one of the first 3 password entries. This is for backward compatibility and also due to the fact that specifying these for a multi UM deployment is unreliable / not recommended due to timing issues with the current setup and replication.
@@ -72,6 +79,12 @@ Custom scripts can be mapped as a host volume to /docker-entrypoint-initdb.d for
 * .sql.gz : gzip compressed sql script
 
 ## Multi Node Cluster compose file
+- If not already built, you have to build the latest MariaDB ColumnStore 1.2 development version using following command:
+
+```
+docker build -t mariadb/columnstore:1.2-dev .
+```
+
 - The docker-compose.yml file will bring up a 1um 2pm cluster using local storage
 per container to allow easy evaluation of a multi node cluster. To run this:
 
@@ -98,4 +111,3 @@ The root password is randomly generated and output to docker logs.
 ```sh
 $ docker-compose down -v
 ```
-

--- a/columnstore/dbinit
+++ b/columnstore/dbinit
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Environment variables supported:
 # - MARIADB_CS_POSTCFG_INPUT - if set runs postConfigure with the value piped into stdin
+# - MARIADB_CS_NUM_BLOCKS_PCT - if set uses this amount of physical memory to utilize for disk block caching
+# - MARIADB_CS_TOTAL_UM_MEMORY - if set uses this amount of physical memory to utilize for joins, intermediate results and set operations on the UM
 # - MARIADB_DATABASE - if set create a database with this name
 
 # file used to track / record initialization and prevent subsequent rerun
@@ -105,13 +107,22 @@ else
     # with this as input. Must stop columnstore service first as postConfigure
     # will fail otherwise. The service is only used for restarted pm1 containers
     # or non pm1 containers in a cluster.
-        # Support backward compat with CS_POSTCFG_INPUT
-        MARIADB_CS_POSTCFG_INPUT="${MARIADB_CS_POSTCFG_INPUT:-$CS_POSTCFG_INPUT}"
+    # Support backward compat with CS_POSTCFG_INPUT
+    MARIADB_CS_POSTCFG_INPUT="${MARIADB_CS_POSTCFG_INPUT:-$CS_POSTCFG_INPUT}"
     if [ ! -z "$MARIADB_CS_POSTCFG_INPUT" ]; then
+		# build the postConfigure command line parameter
+		postConfigureParameter=""
+		if [ ! -z "$MARIADB_CS_NUM_BLOCKS_PCT" ]; then
+			postConfigureParameter="$postConfigureParameter -numBlocksPct $MARIADB_CS_NUM_BLOCKS_PCT"
+		fi
+		if [ ! -z "$MARIADB_CS_TOTAL_UM_MEMORY" ]; then
+			postConfigureParameter="$postConfigureParameter -totalUmMemory $MARIADB_CS_TOTAL_UM_MEMORY"
+		fi
         echo "Stopping columnstore service to run postConfigure"
         /usr/sbin/sv stop columnstore
-        echo -e "$MARIADB_CS_POSTCFG_INPUT" | $MCSDIR/bin/postConfigure -n
-                # Set a columnstore.xml property that can be used to detect postConfigure
+		echo $MCSDIR/bin/postConfigure -n $postConfigureParameter
+        echo -e "$MARIADB_CS_POSTCFG_INPUT" | $MCSDIR/bin/postConfigure -n $postConfigureParameter
+                # Set a Columnstore.xml property that can be used to detect postConfigure
                 # complete from other nodes (as the change is pushed out)
                 if [ 0 -eq $? ]; then
                     $MCSDIR/bin/setConfig Installation FullyConfigured Y

--- a/columnstore/docker-compose.yml
+++ b/columnstore/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   um1:
-    image: mariadb/columnstore:1.2
+    image: mariadb/columnstore:1.2-dev
     environment:
       - MARIADB_CS_POSTCFG_INPUT=
       - MARIADB_RANDOM_ROOT_PASSWORD=
@@ -20,7 +20,7 @@ services:
       - "3306:3306"
 
   pm2:
-    image: mariadb/columnstore:1.2
+    image: mariadb/columnstore:1.2-dev
     environment:
       - MARIADB_CS_POSTCFG_INPUT=
     volumes:
@@ -31,9 +31,11 @@ services:
         ipv4_address: 10.5.0.3
 
   pm1:
-    image: mariadb/columnstore:1.2
+    image: mariadb/columnstore:1.2-dev
     environment:
       - MARIADB_CS_POSTCFG_INPUT=2\n1\nn\ny\ncolumnstore-1\n1\n1\num1\n\n\n2\npm1\n\n\n1\npm2\n\n\n2\n
+      - MARIADB_CS_NUM_BLOCKS_PCT=1024M
+      - MARIADB_CS_TOTAL_UM_MEMORY=512M
     depends_on:
       - um1
       - pm2

--- a/columnstore/mariadb-columnstore.repo
+++ b/columnstore/mariadb-columnstore.repo
@@ -1,5 +1,5 @@
 [mariadb-columnstore]
 name=MariaDB ColumnStore
-baseurl=https://downloads.mariadb.com/MariaDB/mariadb-columnstore/1.2.2/yum/centos/7/x86_64/
+baseurl=http://34.238.186.75/repos/1.2.3-1/nightly/mariadb-columnstore/yum/centos/7/x86_64/
 gpgkey=https://downloads.mariadb.com/MariaDB/mariadb-columnstore/RPM-GPG-KEY-MariaDB-ColumnStore
 gpgcheck=1


### PR DESCRIPTION
totalUmMemory through environment variables.

It uses the Columnstore 1.2.3 development nightly yum repository, which has one [pull request](https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/678) with the necessary postConfigure changes pending.

DO NOT MERGE YET
Once [this](https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/678) is reviewed, approved, and the new nightly yum repository is build by buildbot, this pull request can be reviewed and merged.


If you can't wait and want to test the changes right away you can use following repository in the meantime instead:
http://34.238.186.75/repos/1.2.3-1/TestBuild-MCOL-2068/mariadb-columnstore/yum/centos/7/x86_64/

But, be aware that as long as above mentioned pull request isn't reviewed and merged the interfaces described in above's yum repository might change.