### PR TITLE
DBAAS-4852 - backported changes to startup CS in skysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ COPY scripts/demo \
      scripts/cmapi-restart \
      scripts/columnstore-backup.sh \
      scripts/columnstore-restore.sh \
+     scripts/add-node-to-cluster.sh \
      scripts/mcs-process /usr/bin/
 
 # Add Tini Init Process
@@ -105,6 +106,7 @@ RUN chmod +x /usr/bin/tini \
     /usr/bin/cmapi-restart \
     /usr/bin/columnstore-backup.sh \
     /usr/bin/columnstore-restore.sh \
+    /usr/bin/add-node-to-cluster.sh \
     /usr/bin/mcs-process
 
 # Stream Edit Monit Config

--- a/scripts/add-node-to-cluster.sh
+++ b/scripts/add-node-to-cluster.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Getting the needed variables
+CMAPI_KEY="${CMAPI_KEY:-somekey123}"
+NAMESPACE=$(cat /mnt/skysql/podinfo/namespace)
+DNS_NAME="${HOSTNAME}.${RELEASE_NAME}-mdb-clust.${NAMESPACE}.svc.cluster.local"
+SHORT_DNS_NAME="${HOSTNAME}.${RELEASE_NAME}-mdb-clust"
+
+if [ -z $PM1_DNS ]; then
+    PM1_DNS=$PM1
+fi
+
+# Get last digits of the hostname
+MY_HOSTNAME=$(hostname)
+SPLIT_HOST=(${MY_HOSTNAME//-/ });
+CONT_INDEX=${SPLIT_HOST[(${#SPLIT_HOST[@]}-1)]}
+
+# Wait for CMAPI to be available to add new nodes
+echo "Waiting for CMAPI to be available to add a new node"
+NUM_NODES=$(curl -s https://$PM1_DNS:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .num_nodes -j)
+while [ $? -ne 0 ] || [ "$NUM_NODES" != "$CONT_INDEX" ]; do
+    echo -n "."
+    sleep 3
+    NUM_NODES=$(curl -s https://$PM1_DNS:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .num_nodes -j)
+done
+
+# Adding node to ColumnStore cluster
+echo ""
+echo "Adding node $DNS_NAME to the ColumnStore cluster"
+curl -s -X PUT "https://$PM1_DNS:8640/cmapi/0.4.0/cluster/add-node" --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" --data "{\"timeout\":60, \"node\": \"$DNS_NAME\"}" -k | jq .
+curl -s https://$PM1_DNS:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k | jq .
+
+# Wait for MaxScale to be available
+echo "Waiting for MaxScale to be available"
+MAXSCALE_API_USERNAME=$(cat /mnt/skysql/columnstore-container-configuration/maxscale-api-username)
+MAXSCALE_API_PASSWORD=$(cat /mnt/skysql/columnstore-container-configuration/maxscale-api-password)
+curl -X GET -u ${MAXSCALE_API_USERNAME}:${MAXSCALE_API_PASSWORD} ${RELEASE_NAME}-mariadb-maxscale:8989/v1/maxscale --fail 2>/dev/null >/dev/null
+while [ $? -ne 0 ]; do
+    echo -n "."
+    curl -X GET -u ${MAXSCALE_API_USERNAME}:${MAXSCALE_API_PASSWORD} ${RELEASE_NAME}-mariadb-maxscale:8989/v1/maxscale --fail 2>/dev/null >/dev/null
+done
+
+# Add node to MaxScale
+echo ""
+curl -X GET -u ${MAXSCALE_API_USERNAME}:${MAXSCALE_API_PASSWORD} ${RELEASE_NAME}-mariadb-maxscale:8989/v1/servers/$SHORT_DNS_NAME --fail 2>/dev/null >/dev/null
+if [ $? -ne 0 ]; then
+    echo "Adding server $SHORT_DNS_NAME to MaxScale"
+    curl -X POST -u ${MAXSCALE_API_USERNAME}:${MAXSCALE_API_PASSWORD} ${RELEASE_NAME}-mariadb-maxscale:8989/v1/servers -d '{"data":{"id":"'$SHORT_DNS_NAME'","type":"servers","attributes":{"parameters":{"address":"'$SHORT_DNS_NAME'","protocol":"MariaDBBackend"}},"relationships":{"services":{"data":[{"id":"Read-Write-Service","type":"services"}]},"monitors":{"data":[{"id":"MariaDB-Monitor","type":"monitors"}]}}}}'
+fi

--- a/scripts/cmapi-start
+++ b/scripts/cmapi-start
@@ -44,4 +44,12 @@ echo CMAPI PID = $!
 # Start MariaDB
 /usr/share/mysql/mysql.server start
 
+if [ ! -e $IFLAG ] && [ $SKYSQL_INITIALIZATION -eq 1 ]; then
+    # Initialize the columnstore cluster
+    /usr/bin/add-node-to-cluster.sh
+
+    # Mark Container Initialized
+    touch $IFLAG
+fi
+
 exit 0

--- a/scripts/columnstore-init
+++ b/scripts/columnstore-init
@@ -22,6 +22,11 @@ MAX_PASS="${MAX_PASS:-C0lumnStore!}"
 REP_USER="${REP_USER:-idbrep}"
 REP_PASS="${REP_PASS:-C0lumnStore!}"
 
+# Set network defaults for SkySQL
+if [ -z $PM1_DNS ]; then
+    PM1_DNS=$PM1
+fi
+
 # Miscellaneous Variables
 SERVER_ID=$(hostname -i | cut -d "." -f 4)
 PROGS=('StorageManager' 'load_brm' 'workernode' 'controllernode' 'PrimProc' 'ExeMgr' 'DMLProc' 'DDLProc' 'WriteEngineServer')
@@ -283,7 +288,7 @@ else
 
     $MCS_INSTALL_BIN/mariadb -e "
             STOP SLAVE;
-            CHANGE MASTER TO MASTER_HOST='$PM1',
+            CHANGE MASTER TO MASTER_HOST='$PM1_DNS',
             MASTER_USER='$REP_USER',
             MASTER_PASSWORD='$REP_PASS',
             MASTER_USE_GTID=slave_pos,
@@ -305,8 +310,10 @@ fi
 # Clean Remnants
 rm -f /var/lib/mysql/*.err
 
-# Mark Container Initialized
-touch $IFLAG
+if [ ! $SKYSQL_INITIALIZATION -eq 1 ]; then
+    # Mark Container Initialized
+    touch $IFLAG
+fi
 
 # Return To cmapi-start
 exit 0


### PR DESCRIPTION
Added a script `add-node-to-cluster.sh` to initialize the ColumnStore cluster in SkySQL.
It will be executed if the environment variable `SKYSQL_INITIALIZATION` is set to `1`.

Also introduced a new variable `PM1_DNS` to cope with the differences of k8s' DNS names and docker-compose's.