### PR TITLE
Revert "proper naming for the skysql k8s objects"

### DIFF
--- a/scripts/skysql-specific-startup.sh
+++ b/scripts/skysql-specific-startup.sh
@@ -10,8 +10,8 @@ SKY_IFLAG='/etc/columnstore/skysql-initialization-completed'
 # Getting the needed variables
 CMAPI_KEY="${CMAPI_KEY:-somekey123}"
 NAMESPACE=$(cat /mnt/skysql/podinfo/namespace)
-DNS_NAME="${HOSTNAME}.${RELEASE_NAME}-cs-cluster.${NAMESPACE}.svc.cluster.local"
-SHORT_DNS_NAME="${HOSTNAME}.${RELEASE_NAME}-cs-cluster"
+DNS_NAME="${HOSTNAME}.cs-cluster.${NAMESPACE}.svc.cluster.local"
+SHORT_DNS_NAME="${HOSTNAME}.cs-cluster"
 
 if [ -z $PM1_DNS ]; then
     PM1_DNS=$PM1


### PR DESCRIPTION
This reverts commit 4ff88e37aa53a2e7e1bd27508dc8698c676ee87c.

I'm sorry about that, but apparently there is some issue when the node FQDN/DNS names get too big that I did not know about so I have to revert this