### PR TITLE
Skysql/startup fixes

### DIFF
--- a/scripts/skysql-specific-startup.sh
+++ b/scripts/skysql-specific-startup.sh
@@ -10,8 +10,8 @@ SKY_IFLAG='/etc/columnstore/skysql-initialization-completed'
 # Getting the needed variables
 CMAPI_KEY="${CMAPI_KEY:-somekey123}"
 NAMESPACE=$(cat /mnt/skysql/podinfo/namespace)
-DNS_NAME="${HOSTNAME}.${RELEASE_NAME}-cs-cluster.${NAMESPACE}.svc.cluster.local"
-SHORT_DNS_NAME="${HOSTNAME}.${RELEASE_NAME}-cs-cluster"
+DNS_NAME="${HOSTNAME}.cs-cluster.${NAMESPACE}.svc.cluster.local"
+SHORT_DNS_NAME="${HOSTNAME}.cs-cluster"
 
 if [ -z $PM1_DNS ]; then
     PM1_DNS=$PM1

--- a/scripts/skysql-specific-startup.sh
+++ b/scripts/skysql-specific-startup.sh
@@ -92,6 +92,7 @@ else
             sleep 3
             NUM_NODES=$(curl -s https://$PM1_DNS:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .num_nodes -j)
         done
+        echo ""
         
         # Start the ColumnStore cluster
         echo "Starting the ColumnStore cluster"
@@ -118,8 +119,13 @@ else
             sleep 3
             DBRM_MODE=$(curl -s https://localhost:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .\"$DNS_NAME\".dbrm_mode -j)
         done
+        echo ""
 
+        # give the cmapi service some time to update its status
+        sleep 5
+        
         # in case the DBRM mode is offline start the cluster
+        DBRM_MODE=$(curl -s https://localhost:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .\"$DNS_NAME\".dbrm_mode -j)
         if [ "$DBRM_MODE" == 'offline' ]; then
             echo "Starting the ColumnStore cluster"
             curl -s -X PUT https://localhost:8640/cmapi/0.4.0/cluster/start --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" --data '{"timeout":60}' -k | jq .

--- a/scripts/skysql-specific-startup.sh
+++ b/scripts/skysql-specific-startup.sh
@@ -80,5 +80,56 @@ if [ ! -e $SKY_IFLAG ]; then
     add-node-to-cluster
 else
     echo "SkySQL init flag exists"
-    curl -s -X PUT https://$PM1_DNS:8640/cmapi/0.4.0/cluster/start --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" --data '{"timeout":60}' -k | jq .
+    # Check if we are in a single node deployment (HTAP or CS)
+    if [ $NODES_COUNT -eq 1 ]; then
+        echo "Single node deployment detected"
+
+        # Wait for cmapi to be available (unfortunately it isn't directly available after start)
+        echo "Waiting for cmapi to be available"
+        NUM_NODES=$(curl -s https://$PM1_DNS:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .num_nodes -j)
+        while [ $? -ne 0 ] || [ "$NUM_NODES" != "1" ]; do
+            echo -n "."
+            sleep 3
+            NUM_NODES=$(curl -s https://$PM1_DNS:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .num_nodes -j)
+        done
+        
+        # Start the ColumnStore cluster
+        echo "Starting the ColumnStore cluster"
+        curl -s -X PUT https://$PM1_DNS:8640/cmapi/0.4.0/cluster/start --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" --data '{"timeout":60}' -k | jq .
+
+        # Put the node into read/write mode again
+        echo "Setting the node back into read/write mode"
+        columnstoreDBWrite -c resume
+
+        # In case of HTAP re-add the HTAP UDF
+        if [[ "$CLUSTER_TOPOLOGY" == "htap" ]]; then
+            echo "Re-adding the HTAP UDF"
+            mariadb -e 'CREATE OR REPLACE FUNCTION set_htap_replication RETURNS STRING SONAME "replication.so";'
+            echo "$?"
+        fi
+    else
+        echo "Multi node deployment detected"
+
+        # Wait for cmapi to be available
+        echo "Waiting for cmapi to be available"
+        DBRM_MODE=$(curl -s https://localhost:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .\"$DNS_NAME\".dbrm_mode -j)
+        while [ $? -ne 0 ] || { [ "$DBRM_MODE" != "offline" ] && [ "$DBRM_MODE" != "master" ] && [ "$DBRM_MODE" != "slave" ]; }; do
+            echo -n "."
+            sleep 3
+            DBRM_MODE=$(curl -s https://localhost:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .\"$DNS_NAME\".dbrm_mode -j)
+        done
+
+        # in case the DBRM mode is offline start the cluster
+        if [ "$DBRM_MODE" == 'offline' ]; then
+            echo "Starting the ColumnStore cluster"
+            curl -s -X PUT https://localhost:8640/cmapi/0.4.0/cluster/start --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" --data '{"timeout":60}' -k | jq .
+        fi
+
+        # Put the node into read/write mode again
+        DBRM_MODE=$(curl -s https://localhost:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .\"$DNS_NAME\".dbrm_mode -j)
+        if [ "$DBRM_MODE" != 'offline' ]; then
+            echo "Setting the node back into read/write mode"
+            columnstoreDBWrite -c resume
+        fi
+    fi
 fi

--- a/scripts/skysql-specific-startup.sh
+++ b/scripts/skysql-specific-startup.sh
@@ -122,7 +122,7 @@ else
         echo ""
 
         # give the cmapi service some time to update its status
-        sleep 5
+        sleep 30
         
         # in case the DBRM mode is offline start the cluster
         DBRM_MODE=$(curl -s https://localhost:8640/cmapi/0.4.0/cluster/status --header 'Content-Type:application/json' --header "x-api-key:$CMAPI_KEY" -k --fail | jq .\"$DNS_NAME\".dbrm_mode -j)


### PR DESCRIPTION
- fixes the single node startup
- fixes the multi node startup 
  (note: it is possible that multiple cluster members issue a start cluster command simultaneously - @toddstoffel is this an issue?)
- handles the backup edge cases where a pod is restarted by k8s during its backup