### PR TITLE
fixed cs multinode startup in skysql

### DIFF
--- a/scripts/columnstore-init
+++ b/scripts/columnstore-init
@@ -94,7 +94,7 @@ for i in "${PROGS[@]}" ; do
 done
 
 # Conditional Provisioning
-if [[ $(hostname -s) == "$PM1_DNS" ]]; then
+if [[ "$PM1_DNS" == "$(hostname -s)"* ]]; then
 
     # Start Primary Node
     echo 'Starting primary node...'


### PR DESCRIPTION
https://jira.mariadb.org/browse/DBAAS-7267

`$PM1_DNS` and `$PM1` are different in skysql
```
[root@cs-node-1 /]# echo $PM1_DNS
cs-node-0.cs-cluster
[root@cs-node-1 /]# echo $PM1
cs-node-0
```
Checking with a wildcard should should take care of that