### PR TITLE
Update Dockerfile: move VOLUME instruction after config layer changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,10 +107,7 @@ RUN dnf -y install \
     dnf -y install MariaDB-spider-engine; fi && \
     if [[ "${DEV}" == true ]]; then \
     dnf -y install MariaDB-test; fi
-
-# Create Persistent Volumes
-VOLUME ["/etc/columnstore","/etc/my.cnf.d","/var/lib/mysql","/var/lib/columnstore"]
-
+    
 # Copy Config Files & Scripts To Image
 COPY scripts/provision \
     scripts/provision-mxs \
@@ -146,6 +143,9 @@ RUN printf "%s\n" \
     "" \
     "[application]" \
     "auto_failover = False" >> /etc/columnstore/cmapi_server.conf
+
+# Create Persistent Volumes
+VOLUME ["/etc/columnstore","/etc/my.cnf.d","/var/lib/mysql","/var/lib/columnstore"]
 
 # Make Copies Of MariaDB Related Folders
 RUN /etc/init.d/mariadb stop && \


### PR DESCRIPTION
Have no idea how it works right now. But I have an issue with "Customize cmapi_server.conf". It just does not work for me. That layer is discarded and breaks any cmapi operations in this image.

https://docs.docker.com/engine/reference/builder/#notes-about-specifying-volumes

`Changing the volume from within the Dockerfile: If any build steps change the data within the volume after it has been declared, those changes will be discarded.`